### PR TITLE
vcov(*, complete=FALSE) in a few cases

### DIFF
--- a/R/aovlist-support.R
+++ b/R/aovlist-support.R
@@ -1,5 +1,5 @@
 ##############################################################################
-#    Copyright (c) 2012-2016 Russell V. Lenth                                #
+#    Copyright (c) 2012-2017 Russell V. Lenth                                #
 #                                                                            #
 #    This file is part of the emmeans package for R (*emmeans*)              #
 #                                                                            #
@@ -68,7 +68,7 @@ emm_basis.aovlist = function (object, trms, xlev, grid, vcov., ...) {
     #++Work thru strata in reverse order
     for (nm in rev(nonint)) {
         x = object[[nm]]
-        bi = coef(x)
+        bi = coef(x) # complete=FALSE [in the future]
         bi = bi[!is.na(bi)]
         ii = match(names(bi), xnms)
         Vidx[[nm]] = use = setdiff(ii, which(!is.na(bhat))) #++ omit elts already filled
@@ -76,7 +76,7 @@ emm_basis.aovlist = function (object, trms, xlev, grid, vcov., ...) {
             ii.left = seq_along(ii)[!is.na(match(ii,use))]
             wts[nm, use] = 1
             bhat[use] = bi[ii.left]
-            Vi = vcov(x)[ii.left, ii.left, drop=FALSE]
+            Vi = vcov(x, complete=FALSE)[ii.left, ii.left, drop=FALSE]
             Vmats[[nm]] = Vi
             V[use,use] = Vi
         }

--- a/R/emmGrid-methods.R
+++ b/R/emmGrid-methods.R
@@ -526,8 +526,8 @@ regrid = function(object, transform = c("response", "mu", "unlink", "log", "none
         PB = PB %*% t(object@linfct)
     
     est = .est.se.df(object, do.se = TRUE) ###FALSE)
-    estble = !(is.na(est[[1]]))
-    object@V = vcov(object)[estble, estble, drop=FALSE]
+    estble = !is.na(est[[1]])
+    object@V = vcov(object, complete=FALSE)[estble, estble, drop=FALSE]
     object@bhat = est[[1]]
     object@linfct = diag(1, length(estble))
     if(all(estble))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -553,7 +553,7 @@ emm_basis.glmmadmb = function (object, trms, xlev, grid, ...)
 # Provide for vcov. argument in ref_grid call, which could be a function or a matrix
 
 #' @export
-.my.vcov = function(object, vcov. = stats::vcov, ...) {
+.my.vcov = function(object, vcov. = function(x) stats::vcov(x, complete=FALSE), ...) {
     if (is.function(vcov.))
         vcov. = vcov.(object)
     else if (!is.matrix(vcov.))


### PR DESCRIPTION
As mentioned in an e-mail, the `emmeans`  package has been broken (eg. on CRAN)  by changes in R's development version where   `vcov(*, complete=TRUE)`  has become the new default,
but the `emmeans` package has been relying on the previous default behavior of `vcov()`  which "now" (in R's develoment version) is achievable by `vcov(*, complete=FALSE)`.

(and yes, I'm sorry, my commit message should have said  *FALSE* instead of *TRUE*).

Note that it will probably make sense in the future  to make use of the  `complete = TRUE | FALSE` option in `vcov()`  -- planned also for  `coef()` with the same default for consistency.