### PR TITLE
Fix glht support functions

### DIFF
--- a/R/glht-support.R
+++ b/R/glht-support.R
@@ -102,14 +102,14 @@ glht.emmGrid <- function(model, linfct, by, ...) {
     
     if (is.null(by)) {
         args$linfct = lf
-        return(do.call("glht", args))
+        return(do.call(multcomp::glht, args))
     }
     
     # (else...)
     by.rows = .find.by.rows(object@grid, by)
     result = lapply(by.rows, function(r) {
         args$linfct = lf[r, , drop=FALSE]
-        do.call("glht", args)
+        do.call(multcomp::glht, args)
     })
     bylevs = lapply(by, function(byv) unique(object@grid[[byv]]))
     names(bylevs) = by


### PR DESCRIPTION
Dear Russel,

If `multcomp` is not loaded into the namespace, then the following code throws an error that `glht` is not found:
``` r
lm.cars <- lm(dist ~ speed, data = cars)
multcomp::glht(lm.cars, emmeans::emm(tukey ~ speed))
#> Error in glht(model = structure(list(coefficients = c(`(Intercept)` = -17.5790948905109, : could not find function "glht"
traceback()
#> 4: do.call("glht", args)
#> 3: glht.emmGrid(model, emmo, ...)
#> 2: glht.emmlf(lm.cars, emmeans::emm(tukey ~ speed))
#> 1: multcomp::glht(lm.cars, emmeans::emm(tukey ~ speed))
```
<sup>Created on 2019-07-25 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

The following patch is changing the `do.call` calls to explicitly call `multcomp::glht`. This fixes the issue above, and makes it possible to use `multcomp` and `emmeans` together in packages by putting them in `Imports` instead of `Depends`, and without explicitly importing `glht` from `multcomp`.
For me it passes all the checks and doesn't seem to introduce any regressions.

Thanks for your consideration,
Balazs