### PR TITLE
Preserve linfct colnames in emmeans()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: emmeans
 Type: Package
 Title: Estimated Marginal Means, aka Least-Squares Means
-Version: 1.7.0.00990002
+Version: 1.7.0.00990003
 Date: 2021-11-03
 Authors@R: c(person("Russell V.", "Lenth", role = c("aut", "cre", "cph"), 
     email = "russell-lenth@uiowa.edu"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ title: "NEWS for the emmeans package"
         So by default, the result will have syntactically valid names; this is
         a change, but only because `optional` did not work right (because
         it is an argument for `as.data.frame.list()).
-    
+  * Fix for missing column names in `linfct` from `emmeans()` (#308)
 
 
 

--- a/R/emmeans.R
+++ b/R/emmeans.R
@@ -439,7 +439,8 @@ emmeans = function(object, specs, by = NULL,
                 fac.reduce(RG@linfct[idx, , drop=FALSE])
             })
         
-        linfct = t(matrix(K, nrow = ncol(RG@linfct)))
+        linfct = t(matrix(K, nrow = ncol(RG@linfct),
+                          dimnames = list(colnames(RG@linfct))))
         row.names(linfct) = NULL
         
         if(.some.term.contains(union(facs, RG@roles$trend), RG@model.info$terms))

--- a/tests/testthat/test-emmeans.R
+++ b/tests/testthat/test-emmeans.R
@@ -28,3 +28,7 @@ test_that("Nested EMMs work", {
     expect_equal(colnames(emmeans(rgg, ~ source)@grid)[1:2], c("source","group"))
 })
 
+test_that("Column names in linfct are preserved",
+          expect_equal(colnames(emmeans(rg, "source")@linfct),
+                       colnames(rg@linfct))
+)


### PR DESCRIPTION
Fixes #308 

* add `dimnames` to `matrix()` so the resulting transposed matrix has colnames
* add test 
* add NEWS item
* bump version