### PR TITLE
Fix for mgcv::gam objects without smooth terms

### DIFF
--- a/R/gam-support.R
+++ b/R/gam-support.R
@@ -117,7 +117,7 @@ emm_basis.Gam = function(object, trms, xlev, grid, nboot = 800, ...) {
 ### for mgcv::gam objects
 ### Many thanks to Maarten Jung for help on sorting-out fixed and random effects
 recover_data.gam = function(object, ...) {
-    if(!is.null(object$smooth)) { # get rid of random terms
+    if (length(object$smooth) > 0) { # get rid of random terms
         fixnm = sapply(object$smooth, function(s) {ifelse(inherits(s, "random.effect"), NA, s$term)})
         fixnm = union(.all.vars(delete.response(object$pterms)), fixnm[!is.na(fixnm)])
         object$terms = terms(.reformulate(fixnm, env = environment(terms(object))))
@@ -132,15 +132,15 @@ emm_basis.gam = function(object, trms, xlev, grid,
                          freq = FALSE, unconditional = FALSE,
                          what = c("location", "scale", "shape", "rate", "prob.gt.0"), 
                          ...) {
-    if(!is.null(object$smooth)) { # get rid of random terms 
+    if (length(object$smooth) > 0) { # get rid of random terms 
         rand = sapply(object$smooth, function(s) {ifelse(inherits(s, "random.effect"), s$label, NA)})
-        rand = rand[!is.na(rand)]
+        rand = if (all(is.na(rand))) NULL else rand[!is.na(rand)]
     }
     else
         rand = NULL
-    X = mgcv::predict.gam(object, newdata = grid, type = "lpmatrix", 
-                exclude = rand, newdata.guaranteed = TRUE)
-    keep = apply(X, 2, function(x) !all(x == 0))
+    X = mgcv::predict.gam(object, newdata = grid, type = "lpmatrix",
+                          exclude = rand, newdata.guaranteed = TRUE)
+    keep = if (is.null(rand)) rep(TRUE, ncol(X)) else apply(X, 2, function(x) !all(x == 0))
     X = X[, keep, drop = FALSE]
     bhat = as.numeric(object$coefficients[keep])
     V = .my.vcov(object, freq = freq, unconditional = unconditional, ...)[keep, keep]


### PR DESCRIPTION
The new code (commit [c684910](https://github.com/rvlenth/emmeans/commit/c684910a67de6cb55eaeddd7d15627bbbc5d393a)) for `mgcv::gam` objects looks great, but unfortunately breaks down when there is no smooth term in the model. This is due to `object$smooth` being an empty list, i.e. `list()`, instead of `NULL` when there is no smooth term; so I've implemented the checks via `length(object$smooth) > 0`.
I've added two more suggestions: It might be better to ensure that `NULL` instead of `logical(0)`  is passed to the `exclude` argument of `mgcv::predict.gam` when there is no random term (the latter would implicitly be the case in the current code), and one might want to ensure that all columns are kept when there is no smooth term or random term (there might exist 0-columns in `X` for some other reason which would be kept with the suggested code; *but* if we have both 0-columns corresponding to random terms and 0-columns due to other reasons both will be dropped even with the suggested code. To circumvent this we would need a different way to identify only those columns in `X` that correspond to random terms, maybe something based on a regular expression like 
`keep = !(gsub("(^s\\([[:alnum:]]+\\))\\.[[:digit:]]+$", "\\1", colnames(X)) %in% rand)` or simply 
`keep = !(gsub("\\.[[:digit:]]+", "", colnames(X)) %in% rand)`?