### PR TITLE
make vcov. of class matrix when possible

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -276,7 +276,7 @@ emm_basis.lme = function(object, trms, xlev, grid,
     m = model.frame(trms, grid, na.action = na.pass, xlev = xlev)
     X = model.matrix(trms, m, contrasts.arg = contrasts)
     bhat = nlme::fixef(object)
-    V = .my.vcov(object, ...)
+    V = as.matrix(.my.vcov(object, ...))
     if (sigmaAdjust && object$method == "ML") 
         V = V * object$dims$N / (object$dims$N - nrow(V))
     misc = list()


### PR DESCRIPTION
close issue #381 
In this case I only add `as.matrix` to the `.my.vcov` output. More conservative than https://github.com/rvlenth/emmeans/pull/382, where I had only adapted the code in `emm_basis.merMod`:
- `vcov.` as an argument:
https://github.com/rvlenth/emmeans/blob/fab9f8f954fea09a4a87226463217e0459e76d3f/R/helpers.R#L113
instead of
> User-provided vcov matrices are handled correctly via the `...` argument when they are correctly specified via `vcov.`
- the `if...else` condition later
https://github.com/rvlenth/emmeans/blob/fab9f8f954fea09a4a87226463217e0459e76d3f/R/helpers.R#L120-L123

Thanks!