### PR TITLE
fix lme eval with unknown variables

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -328,7 +328,7 @@ emm_basis.lme = function(object, trms, xlev, grid,
 # model with a few random perturbations of y, then
 # regressing the changes in V against the changes in the 
 # covariance parameters
-gradV.kludge = function(object, Vname = "varFix", call = object$call$fixed, 
+gradV.kludge = function(object, Vname = "varFix", call = formula(object$terms), 
                         data = object$data, extra.iter = 0) {
     # check consistency of contrasts
     #### This code doesn't work with coerced factors. Hardly seems messing with, so I commented it out
@@ -349,7 +349,7 @@ gradV.kludge = function(object, Vname = "varFix", call = object$call$fixed,
     n = length(y)
     dat = t(replicate(2 + extra.iter + length(theta), {
         data[[yname]] = y + sig * rnorm(n)
-        mod = update(object, data = data)
+        mod = update(object, fixed = call, data = data)
         c(attr(mod$apVar, "Pars") - theta, as.numeric(mod[[Vname]] - V))
     }))
     dimnames(dat) = c(NULL, NULL)


### PR DESCRIPTION
This PR claims to solve next issue:
```r
library(nlme)
library(emmeans)
models <-lapply(c(" + Sex"), \(.x) lme(as.formula(paste0("distance  ~ age", .x)), random = ~ 1, data = Orthodont))
emmeans(models[[1]], "Sex", mode = "appx-satterthwaite")
Error in emm_basis.lme(object, trms, xl, grid, misc = attr(data, "misc"),  : 
  Unable to estimate Satterthwaite parameters

# meanwhile next works
fit <- lme(distance  ~ age + Sex, random = ~ 1, data = Orthodont)
emmeans(fit, "Sex", mode = "appx-satterthwaite")
```
which occurs when `emmeans:::gradV.kludge` tries to evaluate the `fixed` effects formula of the `lme` (or `gls`) model through the model`$call$fixed` (an equivalent issue is this one https://github.com/easystats/insight/issues/658, which was solved with an [equivalent solution](https://github.com/easystats/insight/pull/659)) and use it implicitely again through `update`.  Although this component of the model does not keep the fixed effects formula in its final form, it does the `terms` component.