### PR TITLE
Fix so that weights are passed along in ordinal mean.class mode (#553)

### DIFF
--- a/R/ordinal-support.R
+++ b/R/ordinal-support.R
@@ -304,6 +304,7 @@ emm_basis.clm = function (object, trms, xlev, grid,
     prg@roles$multresp = NULL
     newrg@roles = prg@roles
     ## class(newrg) = "ref.grid"
+    newrg@grid$.wgt. = prg@grid$.wgt.[sapply(.find.by.rows(prg@grid, byv), head, 1)]
     update(force_regular(newrg), is.new.rg = TRUE)
 }
 


### PR DESCRIPTION
This was a one-liner. But not that obvious. In the hook function `.clm.mean.class`, look at the code and run in debug mode to see how this fits in. We create a ref grid `.prg` for mode = `"prob"`. Its `@grid` slot has the needed weights, but several copies of each, so I used `.find.by.rows.()` to identify the groups, and each group's weight will be constant, so I pick off the first row in each group and use its weight (next-to-last line in that function).

Another subtlety here is that there is also and `.offset.` column in the grid; that needs to be preserved as it comes from computing the probability for the last category, 1 - (last cum. prob), which is a contrast coef of -1 with an offset of +1 added to that result.