### PR TITLE
Add names in `pairs.emm_list` only in case the returned object is a list

### DIFF
--- a/R/emm-list.R
+++ b/R/emm-list.R
@@ -191,7 +191,8 @@ contrast.emm_list = function(object, ... , which = NULL) {
 pairs.emm_list = function(x, ..., which = NULL) {
     which = .guess.which(x, which)
     rtn = .lapply(x[which], pairs, ...)
-    names(rtn) = paste("comparisons of", names(rtn))
+    if (is.list(rtn))
+      names(rtn) = paste("comparisons of", names(rtn))
     rtn
 }
 


### PR DESCRIPTION
Thanks for this package, it is very useful!
When working on a project, I realize that some code that used to work now signal an error.
Here is a reprex:
``` r
library(emmeans)
#> Welcome to emmeans.
#> Caution: You lose important information if you filter this package's results.
#> See '? untidy'
warp.lm <- lm(breaks ~ wool * tension, data = warpbreaks)
emm <- emmeans (warp.lm, ~ wool | tension)
pairs(emm)
#> tension = L:
#>  contrast estimate   SE df t.ratio p.value
#>  A - B       16.33 5.16 48   3.167  0.0027
#> 
#> tension = M:
#>  contrast estimate   SE df t.ratio p.value
#>  A - B       -4.78 5.16 48  -0.926  0.3589
#> 
#> tension = H:
#>  contrast estimate   SE df t.ratio p.value
#>  A - B        5.78 5.16 48   1.120  0.2682

emm <- emmeans (warp.lm, pairwise ~ wool | tension)
pairs(emm)
#> Error in names(rtn) <- paste("comparisons of", names(rtn)): invalid to use names()<- on an S4 object of class 'emmGrid'
```

The old behavior was that the output of the second call `pairs(emm)` was the same as the first one.
(I am aware that it is not useful to use `pairwise` in the left-hand side of the formula since we use `pairs` later, but I would not expect this to cause this error message).

I think this change was introduced by commit d8842bef1a8b5c51625076b3f6e8daf27dd3ef91 which modified this function:
https://github.com/rvlenth/emmeans/blob/16a8ed8865adfd6efee6e26821602cb6523fb183/R/emm-list.R#L191-L196

However, when `rtn` is a list with only one objet, `.lapply` drops it and only return that object. This causes the call to `names()<-` to fail.
This PR proposes to test whether the `rtn` is a list before trying to change the names in line 194 (as is done a few lines above for the method `contrast.emm_list`).