### PR TITLE
Fix `atanh` `mu.eta` so `type = "response"` works

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ title: "NEWS for the emmeans package"
 ## emmeans 2.0.4
   * Updated logo (now hexagonal)
   * bug-fix for labelling in pairwise contrasts
+  * Fixed an error in the `atanh` response transformation: a typo in its
+    `mu.eta` derivative (`tanh^2(eta)`) made `type = "response"` fail
 
 ## emmeans 2.0.3
   * Repaired `contrast` so that it recognizes multivariate transformations 

--- a/R/transformations.R
+++ b/R/transformations.R
@@ -301,7 +301,7 @@ make.tran = function(type = c("genlog", "power", "boxcox", "sympower",
                mu.lbl = ifelse(alpha == 1, "mu", paste0("mu/", round(alpha,3)))
                list(linkfun = function(mu) atanh(mu/alpha),
                     linkinv = function(eta) alpha * tanh(eta),
-                    mu.eta = function(eta) alpha * (1 - tanh^2(eta)),
+                    mu.eta = function(eta) alpha * (1 - tanh(eta)^2),
                     valideta = function (eta) all(is.finite(eta)) && all(eta > -1) && all(eta < 1),
                     alpha = alpha,
                     name = paste0("atanh(", mu.lbl, ")")

--- a/tests/testthat/test-transformations.R
+++ b/tests/testthat/test-transformations.R
@@ -1,0 +1,19 @@
+context("response transformations")
+
+# atanh transformation: mu.eta derivative must work so type = "response"
+# can compute back-transformed estimates and delta-method SEs.
+# Regression test for the typo `tanh^2(eta)` in the atanh mu.eta.
+test_that("atanh response transformation supports type = 'response'", {
+    rng <- range(iris$Sepal.Width)
+    r <- 1.8 * (iris$Sepal.Width - rng[1]) / (rng[2] - rng[1]) - 0.9  # in (-0.9, 0.9)
+    dat <- data.frame(r = r, Species = iris$Species)
+    mod <- lm(atanh(r) ~ Species, data = dat)
+
+    lk <- summary(emmeans(mod, "Species"))                  # link (atanh) scale
+    rs <- summary(emmeans(mod, "Species"), type = "response")  # must not error
+
+    # back-transform is tanh() of the link-scale means
+    expect_equal(rs$response, tanh(lk$emmean), tolerance = 1e-8)
+    # delta-method SEs are finite and positive
+    expect_true(all(is.finite(rs$SE)) && all(rs$SE > 0))
+})


### PR DESCRIPTION
The `atanh` response transformation defines its `mu.eta` derivative as
`alpha * (1 - tanh^2(eta))`. That is invalid R: `tanh^2` applies `^` to the
`tanh` closure, so any back-transformation (`type = "response"`) of an
`atanh`-transformed response errors out. The intended derivative of the inverse
link `alpha * tanh(eta)` is `alpha * (1 - tanh(eta)^2)`.

``` r
rng <- range(iris$Sepal.Width)
iris$r <- 1.8 * (iris$Sepal.Width - rng[1]) / (rng[2] - rng[1]) - 0.9  # in (-0.9, 0.9)
mod <- lm(atanh(r) ~ Species, data = iris)

# --- before:
emmeans(mod, "Species", type = "response")
## Error in alpha * (1 - tanh^2(eta)) : attempt to apply non-function

# --- after:
emmeans(mod, "Species", type = "response")
##  Species    response     SE  df lower.CL upper.CL
##  setosa        0.194 0.0427 147    0.108    0.276
##  versicolor   -0.352 0.0388 147   -0.426   -0.273
##  virginica    -0.180 0.0429 147   -0.263   -0.094
##
## Intervals are back-transformed from the atanh(mu) scale
```

Root cause: `R/transformations.R`, the `atanh` branch's `mu.eta`. Present since
the `make.tran()` revamp (commit 22f1ffc, 2022-12-02; first shipped in 1.8.3) —
the `type = "response"` path for this transformation appears to be untested.
Added a regression test in `tests/testthat/test-transformations.R`.

Found via an AI-assisted bug hunt (see #580).
