### PR TITLE
Ignore `cross.adjust` when `by` groups are unequal sizes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ title: "NEWS for the emmeans package"
 ## emmeans 2.0.4
   * Updated logo (now hexagonal)
   * bug-fix for labelling in pairwise contrasts
+  * `cross.adjust` is now correctly ignored (as documented) when the `by`
+    groups are not all the same size, rather than silently producing
+    mis-shaped (recycled) adjusted P values
 
 ## emmeans 2.0.3
   * Repaired `contrast` so that it recognizes multivariate transformations 

--- a/R/summary.R
+++ b/R/summary.R
@@ -716,8 +716,9 @@ summary.emmGrid <- function(object, infer, level, adjust, by,
         }
         
         # Handle cross-adjustments
-        if ( (length(by.rows) > 1) && 
+        if ( (length(by.rows) > 1) &&
              (length(len <- sapply(by.rows, length)) > 1) &&
+             (length(unique(len)) == 1) &&   # all by groups must be the same size
              is.na(pmatch(cross.adjust, "none")) ) {
             val = c("sidak", p.adjust.methods)
             w = pmatch(tolower(cross.adjust), tolower(val))

--- a/tests/testthat/test-cross-adjust.R
+++ b/tests/testthat/test-cross-adjust.R
@@ -1,0 +1,37 @@
+context("cross-group P-value adjustment")
+
+# cross.adjust is documented to be ignored unless all 'by' groups are the
+# same size. Previously the guard only checked the NUMBER of by groups, so
+# unequal sizes caused matrix() recycling and silently wrong adjusted P values.
+test_that("cross.adjust is ignored for unequal-size by groups", {
+    warp.lm <- lm(breaks ~ wool * tension, data = warpbreaks)
+    prs <- pairs(emmeans(warp.lm, ~ tension | wool))
+    uneq <- prs[-1]   # wool A: 2 comparisons, wool B: 3 -> unequal sizes
+
+    base <- suppressMessages(
+        test(uneq, by = "wool", adjust = "tukey", cross.adjust = "none"))
+
+    # must not warn (no recycling) ...
+    expect_warning(
+        cross <- suppressMessages(
+            test(uneq, by = "wool", adjust = "tukey", cross.adjust = "bonferroni")),
+        regexp = NA)
+    # ... and must equal the 'none' result (cross.adjust ignored as documented)
+    expect_equal(cross$p.value, base$p.value)
+})
+
+# Positive control: with EQUAL-size by groups, cross.adjust must still be
+# applied (this is the documented, working case - the fix must not disable it).
+test_that("cross.adjust is still applied for equal-size by groups", {
+    warp.lm <- lm(breaks ~ wool * tension, data = warpbreaks)
+    eq <- pairs(emmeans(warp.lm, ~ tension | wool))   # wool A: 3, wool B: 3
+
+    base  <- suppressMessages(
+        test(eq, by = "wool", adjust = "tukey", cross.adjust = "none"))
+    cross <- suppressMessages(
+        test(eq, by = "wool", adjust = "tukey", cross.adjust = "bonferroni"))
+
+    # cross.adjust must change (inflate) the P values across the two by groups
+    expect_false(isTRUE(all.equal(cross$p.value, base$p.value)))
+    expect_true(all(cross$p.value >= base$p.value - 1e-12))
+})


### PR DESCRIPTION
`?summary.emmGrid` says of `cross.adjust`: *"This argument is ignored unless …
they are all the same size."* The guard that enables cross-adjustment only
tests the *number* of `by` groups, never that the group sizes are equal:

``` r
if ( (length(by.rows) > 1) &&
     (length(len <- sapply(by.rows, length)) > 1) &&   # = number of by groups (redundant)
     is.na(pmatch(cross.adjust, "none")) ) {
    ...
    mat = matrix(result$p.value[bridx], nrow = len)   # len is a vector -> uses len[1], recycles
```

With unequal-size `by` groups, `matrix(..., nrow = len)` uses `len[1]` and
recycles the P-value vector, so the adjusted P values are silently wrong (and
two recycling warnings are emitted).

``` r
warp.lm <- lm(breaks ~ wool * tension, data = warpbreaks)
uneq <- pairs(emmeans(warp.lm, ~ tension | wool))[-1]  # wool A: 2 comparisons, B: 3 -> unequal
base  <- test(uneq, by = "wool", adjust = "tukey", cross.adjust = "none")

# --- before: cross.adjust changes the P values (it should be ignored), with warnings
test(uneq, by = "wool", adjust = "tukey", cross.adjust = "bonferroni")
## Warning: data length [5] is not a sub-multiple or multiple of the number of rows [2]
## Warning: number of items to replace is not a multiple of replacement length
## ... (P values differ from `base`) ...
isTRUE(all.equal(base$p.value,
                 test(uneq, by="wool", adjust="tukey", cross.adjust="bonferroni")$p.value))
## [1] FALSE

# --- after: cross.adjust is ignored (as documented), no warnings, P values unchanged
isTRUE(all.equal(base$p.value,
                 test(uneq, by="wool", adjust="tukey", cross.adjust="bonferroni")$p.value))
## [1] TRUE
```

Fix: add the documented equal-size check `length(unique(len)) == 1` to the
guard in `R/summary.R`. The guard has tested only the group *count* since
`cross.adjust` was introduced (commit ea4dd91, shipped in 1.9.0). Equal-size
`by` groups are unaffected: the regression test in
`tests/testthat/test-cross-adjust.R` covers both directions — `cross.adjust` is
ignored for unequal sizes (no recycling warnings, P values match `"none"`) and
still applied for equal sizes (P values change as before).

Found via an AI-assisted bug hunt (see #580).
