### PR TITLE
`head()`/`tail()` for `emmGrid`: follow base-R negative-`n` semantics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ title: "NEWS for the emmeans package"
 ## emmeans 2.0.4
   * Updated logo (now hexagonal)
   * bug-fix for labelling in pairwise contrasts
+  * `head()` and `tail()` for `emmGrid` objects now follow base-R semantics
+    for a negative `n` (previously the two were effectively swapped)
 
 ## emmeans 2.0.3
   * Repaired `contrast` so that it recognizes multivariate transformations 

--- a/R/rbind.R
+++ b/R/rbind.R
@@ -174,9 +174,9 @@ subset.emmGrid = function(x, subset, ...) {
 #' @method head emmGrid
 #' @export
 head.emmGrid = function(x, n = 6, ...) {
-    s = sign(n[1])
-    n = min(abs(n[1]), nrow(x@grid))
-    x[s * seq_len(n)]
+    N = nrow(x@grid)
+    n = if (n[1] < 0) max(N + n[1], 0L) else min(n[1], N)
+    x[seq_len(n)]
 }
 
 #' @rdname rbind.emmGrid
@@ -185,9 +185,8 @@ head.emmGrid = function(x, n = 6, ...) {
 #' @method tail emmGrid
 #' @export
 tail.emmGrid = function(x, n = 6, ...) {
-    s = sign(n[1])
     N = nrow(x@grid)
-    n = min(abs(n[1]), N)
-    x[s * (seq_len(n) - n + N)]
+    n = if (n[1] < 0) max(N + n[1], 0L) else min(n[1], N)
+    x[seq_len(n) + (N - n)]
 }
 

--- a/tests/testthat/test-head-tail.R
+++ b/tests/testthat/test-head-tail.R
@@ -1,0 +1,20 @@
+context("head/tail for emmGrid")
+
+# head()/tail() for emmGrid should match base-R semantics, including a
+# negative n. Previously the negative-n branches of head and tail were
+# effectively swapped.
+test_that("head()/tail() honor base-R negative-n semantics", {
+    warp.rg <- ref_grid(lm(breaks ~ wool * tension, data = warpbreaks))
+    ten <- as.character(warp.rg@grid$tension)   # 6 rows: L L M M H H
+    expect_equal(length(ten), 6L)
+
+    gten <- function(x) as.character(x@grid$tension)
+
+    # positive n: first / last n rows
+    expect_equal(gten(head(warp.rg, 3)), ten[1:3])
+    expect_equal(gten(tail(warp.rg, 3)), ten[4:6])
+
+    # negative n (base R): head(-2) drops the LAST 2; tail(-2) drops the FIRST 2
+    expect_equal(gten(head(warp.rg, -2)), ten[1:4])
+    expect_equal(gten(tail(warp.rg, -2)), ten[3:6])
+})


### PR DESCRIPTION
In base R, `head(x, -k)` drops the **last** k elements and `tail(x, -k)` drops
the **first** k. The `emmGrid` methods have these swapped for a negative `n`:
`head.emmGrid(x, -k)` drops the first k rows and `tail.emmGrid(x, -k)` drops the
last k. Positive `n` is fine.

``` r
warp.rg <- ref_grid(lm(breaks ~ wool * tension, data = warpbreaks))  # 6 rows: L L M M H H (tension)

head(1:6, -2)   # base-R reference: 1 2 3 4  (drop last 2)
tail(1:6, -2)   # base-R reference: 3 4 5 6  (drop first 2)

# --- before:
as.character(head(warp.rg, -2)@grid$tension)   # "M" "M" "H" "H"   (dropped the FIRST 2)
as.character(tail(warp.rg, -2)@grid$tension)   # "L" "L" "M" "M"   (dropped the LAST 2)

# --- after:
as.character(head(warp.rg, -2)@grid$tension)   # "L" "L" "M" "M"   (drops the last 2)
as.character(tail(warp.rg, -2)@grid$tension)   # "M" "M" "H" "H"   (drops the first 2)
```

Fix: rewrote both methods in `R/rbind.R` to compute the kept-row count exactly
the way `utils:::head.default()` / `tail.default()` do — `max(N + n, 0L)` for a
negative `n` — using positive indexing only. `n = 0` and `abs(n) > nrow` return
an empty grid, matching base behavior; positive `n` is unchanged. Present since
the `head()`/`tail()` methods were added (commit 3a63e5d, 2022-08-30; first
shipped in 1.8.1); the help page has no negative-`n` example, so no documented
behavior changes. The only internal callers use positive `n`, so package
internals are unaffected. Added a regression test in
`tests/testthat/test-head-tail.R`.

Found via an AI-assisted bug hunt (see #580).
