### PR TITLE
Fix `emmip(engine = "lattice")` to use its axis/trace labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ title: "NEWS for the emmeans package"
 ## emmeans 2.0.4
   * Updated logo (now hexagonal)
   * bug-fix for labelling in pairwise contrasts
+  * `emmip(..., engine = "lattice")` now uses the axis/trace labels again
+    (a typo referenced the wrong object, so the labels were silently dropped)
 
 ## emmeans 2.0.3
   * Repaired `contrast` so that it recognizes multivariate transformations 

--- a/R/emmip.R
+++ b/R/emmip.R
@@ -548,7 +548,7 @@ emmip_lattice = function(emms, style = "factor",
                          xlab = labs$xlab, ylab = labs$ylab, tlab = labs$tlab, 
                          pch = c(1,2,6,7,9,10,15:20), 
                          lty = 1, col = NULL, ...) {
-    labs = attr(emm, "labs")
+    labs = attr(emms, "labs")
     vars = attr(emms, "vars")
     
     # The strips the way I want them

--- a/tests/testthat/test-emmip.R
+++ b/tests/testthat/test-emmip.R
@@ -1,0 +1,22 @@
+context("emmip")
+
+# The lattice engine read its labels from a non-existent object (a typo:
+# attr(emm, ...) instead of attr(emms, ...)), so axis/trace labels were
+# silently dropped. They should match the labels used by the ggplot engine.
+test_that("emmip lattice engine keeps axis labels", {
+    skip_if_not_installed("lattice")
+    warp.lm <- lm(breaks ~ wool * tension, data = warpbreaks)
+
+    tmp <- tempfile(fileext = ".pdf"); pdf(tmp)
+    on.exit({ dev.off(); unlink(tmp) })
+
+    p_lat <- emmip(warp.lm, wool ~ tension, engine = "lattice")
+    p_gg  <- emmip(warp.lm, wool ~ tension, engine = "ggplot")
+
+    expect_s3_class(p_lat, "trellis")
+    expect_false(is.null(p_lat$xlab))
+    expect_false(is.null(p_lat$ylab))
+    # lattice labels match the ggplot engine's labels
+    expect_equal(p_lat$xlab, p_gg$labels$x)
+    expect_equal(p_lat$ylab, p_gg$labels$y)
+})


### PR DESCRIPTION
`emmip_lattice()` reads `labs = attr(emm, "labs")`, but its argument is named
`emms` (the parallel `emmip_ggplot()` correctly uses `attr(emms, "labs")`). This
doesn't error only because an unrelated `emm` object exists in the namespace;
`attr(emm, "labs")` returns `NULL`, so the `xlab`/`ylab`/`tlab` defaults all
become `NULL` and the lattice plot silently loses its labels. This affects the
lattice example shown on the `emmip` help page.

``` r
warp.lm <- lm(breaks ~ wool * tension, data = warpbreaks)
p <- emmip(warp.lm, wool ~ tension, engine = "lattice")

# --- before:
p$xlab   # NULL
p$ylab   # NULL

# --- after (matches the ggplot engine):
p$xlab   # "Levels of tension"
p$ylab   # "Linear prediction"
```

Fix: `attr(emm, "labs")` -> `attr(emms, "labs")` in `R/emmip.R`. Present since
the `emmip()` rendering functions were added (commit 0d3297e, 2020-12-04). Added
a regression test in `tests/testthat/test-emmip.R` that checks the lattice
engine's labels match the ggplot engine's.

Found via an AI-assisted bug hunt (see #580).
