### PR TITLE
Fix cls assignment precedence in as.emmGrid

### DIFF
--- a/R/emmeans.R
+++ b/R/emmeans.R
@@ -751,7 +751,8 @@ emmobj = function(bhat, V, levels, linfct = diag(length(bhat)), df = NA, dffun, 
 #' pigs.anew <- as.emmGrid(pigs.sav)
 #' emmeans(pigs.anew, "source")
 as.emmGrid = function(object, ...) {
-    if (cls <- class(object)[1] %in% c("ref.grid", "lsmobj")) {
+    cls <- class(object)[1]
+    if (cls %in% c("ref.grid", "lsmobj")) {
         object = as.list.emmGrid(object)
         if (is.null(object$misc$is.new.rg))
             object$misc$is.new.rg = (cls == "ref.grid")


### PR DESCRIPTION
cls <- class(object)[1] %in% c("ref.grid","lsmobj") assigned the %in% result (a logical) to cls because %in% binds tighter than <-. The subsequent cls == "ref.grid" then compared a logical to a character and was always FALSE, so is.new.rg was mis-set for ref.grid objects. Capture the class string first, then test.

Found during my large https://github.com/sims1253/ry audit