### PR TITLE
Changes to `.reformulate` and `recover_data.call`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,6 +15,9 @@
 # This keeps showing up lately, but I don't want it
 ^Rplots.pdf
 
+.lintr
+.lintr/*
+
 # Issue templates etc.
 .github
 .github/*

--- a/R/0nly-internal.R
+++ b/R/0nly-internal.R
@@ -275,7 +275,7 @@
         stop("'termlabels' must be a character vector of length at least one")
     has.resp = !is.null(response)
     termlabels = sapply(trimws(termlabels), function(x)
-        if (length(grep("\\$|\\[\\[", x)) > 0) x
+        if (length(grep("\\$|\\[\\[|\\(", x)) > 0) x
         else paste0("`", x, "`"))
     termtext = paste(if (has.resp) "response", "~",
                      paste(termlabels, collapse = "+"), collapse = "")

--- a/R/interfacing.R
+++ b/R/interfacing.R
@@ -208,11 +208,9 @@ recover_data.call = function(object, trms, na.action, data = NULL,
         # frame is typically object$model, and we can often use it instead of 
         # recreating the dataset. But the exception is when its names include
         # things like 'offset(n)' or 'I(x^2)'
-        if (is.null(data)) {
-            frmfrm = paste("~", paste(names(frame), collapse = "+")) |> as.formula()
-            if (!.has.fcns(frmfrm))
+        if (is.null(data)) 
+            if (!.has.fcns(.reformulate(names(frame))))
                 data = frame
-        }
         if ("(offset)" %in% names(data))
             vars = union(vars, "(offset)")
     }


### PR DESCRIPTION
to fix the new issue with spaces in variable names.

This is simpler than what I suggested by email. In `recover_data.call()`, we simply use `.reformulate()` instead of that pasting stuff to construct the needed formula to pass to `.has.fcns()`; and in `.reformulate()`, I modified it so it doesn't put backticks around function calls.

In checking, I also noticed that `,lintr` needed to be added to `Rbuildignore`